### PR TITLE
feature/ 검색창 드롭다운(최근검색어, 인기검색어) 레이아웃 구현 및 css update

### DIFF
--- a/src/components/common/molecules/HeaderBtn.jsx
+++ b/src/components/common/molecules/HeaderBtn.jsx
@@ -17,7 +17,7 @@ export default function HeaderBtn() {
       </Btn>
       {/* 임시방편 */}
       <Btn>
-        <StyledLink href="auth/requests">내요청</StyledLink>
+        <StyledLink href="/auth/requests">내요청</StyledLink>
       </Btn>
     </HeaderRow>
   );

--- a/src/components/common/organisms/Header.jsx
+++ b/src/components/common/organisms/Header.jsx
@@ -6,12 +6,12 @@ import { LogoText, Row } from "@/styles/commonStyles";
 import HeaderBtn from "../molecules/HeaderBtn";
 import Link from "next/link";
 
-export default function Header({ isHome }) {
+export default function Header({ $isHome }) {
   return (
-    <Container isHome={isHome}>
+    <Container $isHome={$isHome}>
       <Inner>
         <HeaderBtn />
-        {!isHome && (
+        {!$isHome && (
           <HeaderRow>
             <SmallLogoText>
               <StyledLink href="/">머라카노</StyledLink>
@@ -29,9 +29,14 @@ const Container = styled.div`
   flex-direction: column;
   align-items: center;
   justify-content: center;
+  position: fixed;
+  z-index: 100;
+  background-color: white;
+  top: 0;
+  left: 0;
   height: 130px;
   width: 100vw;
-  border-bottom: ${(props) => (props.isHome ? "none" : "1px solid #cccccc")};
+  border-bottom: ${(props) => (props.$isHome ? "none" : "1px solid #cccccc")};
 `;
 
 const Inner = styled.div`

--- a/src/components/common/organisms/Header.jsx
+++ b/src/components/common/organisms/Header.jsx
@@ -5,6 +5,7 @@ import SearchBar from "@/components/search/atoms/SearchBar";
 import { LogoText, Row } from "@/styles/commonStyles";
 import HeaderBtn from "../molecules/HeaderBtn";
 import Link from "next/link";
+import { Container } from "@/styles/commonStyles";
 
 export default function Header({ $isHome }) {
   return (
@@ -23,21 +24,6 @@ export default function Header({ $isHome }) {
     </Container>
   );
 }
-
-const Container = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  position: fixed;
-  z-index: 100;
-  background-color: white;
-  top: 0;
-  left: 0;
-  height: 130px;
-  width: 100vw;
-  border-bottom: ${(props) => (props.$isHome ? "none" : "1px solid #cccccc")};
-`;
 
 const Inner = styled.div`
   display: flex;

--- a/src/components/search/atoms/RecentItem.jsx
+++ b/src/components/search/atoms/RecentItem.jsx
@@ -1,0 +1,49 @@
+import styled from "styled-components";
+import { CloseOutlined } from "@ant-design/icons";
+import { ResetLink } from "@/styles/commonStyles";
+
+export function RecentItem({ children, onRemove }) {
+  return (
+    <DDItem>
+      <ResetLink href={`/search?query=${children || ""}`}>
+        <DDText>{children || "최근 검색어가 없습니다."}</DDText>
+      </ResetLink>
+
+      {children && <CloseIcon onClick={() => onRemove(children)} />}
+    </DDItem>
+  );
+}
+
+const DDItem = styled.li`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  height: 18px;
+  color: #666666;
+  overflow: hidden;
+  font-size: 16px;
+  font-weight: 400;
+`;
+
+const DDText = styled.div`
+  padding-top: 2px;
+  width: 190px;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  color: #666666;
+
+  &:hover {
+    color: #000000;
+    background-color: var(--secondary10);
+  }
+`;
+
+const CloseIcon = styled(CloseOutlined)`
+  font-size: 10px;
+  cursor: pointer;
+  &:hover {
+    color: #000000;
+  }
+`;

--- a/src/components/search/atoms/SearchBar.jsx
+++ b/src/components/search/atoms/SearchBar.jsx
@@ -33,8 +33,8 @@ export default function SearchBar({ header }) {
     };
   }, []);
   return (
-    <Column>
-      <SearchBarContainer header={header} ref={searchBarRef}>
+    <Column ref={searchBarRef}>
+      <SearchBarContainer header={header}>
         <SearchInput
           header={header}
           type="text"

--- a/src/components/search/atoms/SearchBar.jsx
+++ b/src/components/search/atoms/SearchBar.jsx
@@ -41,7 +41,7 @@ export default function SearchBar({ header }) {
           value={searchTerm}
           onChange={(e) => setSearchTerm(e.target.value)}
           onClick={() => setDropdownVisible(true)}
-          placeholder="영어 개발 용어를 검색해보세요."
+          placeholder="발음이 궁금한 영어 개발 용어를 검색해보세요."
         />
         <Icon onClick={handleSearch}>
           <StyledSearchOutlined />

--- a/src/components/search/atoms/SearchBar.jsx
+++ b/src/components/search/atoms/SearchBar.jsx
@@ -1,33 +1,53 @@
 // src/components/search/atoms/SearchBar.js
-import { useState } from "react";
+import { useState, useRef, useEffect } from "react";
 import { useRouter } from "next/router";
 import {
   SearchBarContainer,
   SearchInput,
   Icon,
   StyledSearchOutlined,
+  Column,
 } from "@/styles/commonStyles";
+import SearchDropdown from "@/components/search/molecules/SearchDropdown";
 
 export default function SearchBar({ header }) {
   const [searchTerm, setSearchTerm] = useState("");
+  const [isDropdownVisible, setDropdownVisible] = useState(false);
   const router = useRouter();
+  const searchBarRef = useRef();
 
   const handleSearch = () => {
     router.push(`/search?query=${searchTerm}`);
   };
 
+  const handleClickOutside = (event) => {
+    if (searchBarRef.current && !searchBarRef.current.contains(event.target)) {
+      setDropdownVisible(false);
+    }
+  };
+
+  useEffect(() => {
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, []);
   return (
-    <SearchBarContainer header={header}>
-      <SearchInput
-        header={header}
-        type="text"
-        value={searchTerm}
-        onChange={(e) => setSearchTerm(e.target.value)}
-        placeholder="영어 개발 용어를 검색해보세요."
-      />
-      <Icon onClick={handleSearch}>
-        <StyledSearchOutlined />
-      </Icon>
-    </SearchBarContainer>
+    <Column>
+      <SearchBarContainer header={header} ref={searchBarRef}>
+        <SearchInput
+          header={header}
+          type="text"
+          value={searchTerm}
+          onChange={(e) => setSearchTerm(e.target.value)}
+          onClick={() => setDropdownVisible(true)}
+          placeholder="영어 개발 용어를 검색해보세요."
+        />
+        <Icon onClick={handleSearch}>
+          <StyledSearchOutlined />
+        </Icon>
+      </SearchBarContainer>
+      {isDropdownVisible && <SearchDropdown />}
+    </Column>
   );
 }

--- a/src/components/search/molecules/SearchDropdown.jsx
+++ b/src/components/search/molecules/SearchDropdown.jsx
@@ -1,0 +1,114 @@
+import React, { useState } from "react";
+import styled from "styled-components";
+import { RecentItem } from "../atoms/RecentItem";
+
+export default function SearchDropdown() {
+  // TODO : 임시저장, 추후 API 연동
+  const [recentSearches, setRecentSearches] = useState([
+    "React",
+    "ACID",
+    "DOM",
+    "IDE",
+  ]); // 최근 검색어
+
+  const [popularSearches, setPopularSearches] = useState([
+    "CSSOM",
+    "ACID",
+    "ASAP",
+    "AZURE",
+  ]); // 인기 검색어
+
+  // 검색어를 추가하는 함수
+  const addSearchTerm = (term) => {
+    setRecentSearches((prevSearches) => [term, ...prevSearches]);
+  };
+
+  // 검색어를 삭제하는 함수
+  const removeSearchTerm = (term) => {
+    setRecentSearches((prevSearches) =>
+      prevSearches.filter((search) => search !== term)
+    );
+  };
+
+  return (
+    <DDContainer>
+      <DDSection borderRight>
+        <SectionTitle>최근 검색어</SectionTitle>
+        <List>
+          {recentSearches.length > 0 ? (
+            recentSearches.map((item, index) => (
+              <RecentItem key={index} onRemove={removeSearchTerm}>
+                {item}
+              </RecentItem> // 각 검색어에 대한 RecentItem 컴포넌트를 생성
+            ))
+          ) : (
+            <RecentItem /> // recentSearches 배열이 비어있을 경우 children prop을 전달하지 않음
+          )}
+        </List>
+      </DDSection>
+      <DDSection>
+        <SectionTitle>인기 검색어</SectionTitle>
+        <List>
+          <DDItem>React</DDItem>
+          <DDItem>React</DDItem>
+          <DDItem>React</DDItem>
+          <DDItem>React</DDItem>
+        </List>
+      </DDSection>
+    </DDContainer>
+  );
+}
+
+const DDContainer = styled.div`
+  width: 580px;
+  height: 358px;
+  margin-top: 23px;
+  box-sizing: border-box;
+  border-radius: 30px;
+  border: 2px solid var(--secondary);
+  display: flex;
+`;
+
+const DDSection = styled.div`
+  padding: 25px 36px;
+  border-right: ${(props) =>
+    props.borderRight ? "1px solid var(--secondary)" : "none"};
+  width: 50%;
+`;
+
+const SectionTitle = styled.div`
+  font-size: 16px;
+  font-weight: 600;
+  margin-bottom: 20px;
+  height: 18px;
+  line-height: 18px;
+  /* background-color: var(--secondary); */
+`;
+
+const List = styled.ul`
+  display: flex;
+  flex-direction: column;
+  /* flex-wrap: wrap; */
+  gap: 10px;
+`;
+
+const DDItem = styled.li`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  height: 18px;
+  /* background-color: var(--secondary); */
+  color: #666666;
+  overflow: hidden;
+  font-size: 16px;
+  font-weight: 400;
+`;
+
+const DDText = styled.div`
+  padding-top: 2px;
+  width: 190px;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+`;

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -4,6 +4,7 @@ import styled from "styled-components";
 import { LogoText } from "@/styles/commonStyles";
 import SearchBar from "@/components/search/atoms/SearchBar";
 import router from "next/router";
+import SearchDropdown from "@/components/search/molecules/SearchDropdown";
 
 export default function Search() {
   // 메인 홈 이동
@@ -13,7 +14,7 @@ export default function Search() {
 
   return (
     <Container>
-      <Header isHome />
+      <Header $isHome />
       <Section>
         <Title onClick={redirectToHome}>
           <Logo />
@@ -21,17 +22,21 @@ export default function Search() {
         </Title>
         <SubText>개발자들을 위한 한국어 발음 검색 서비스</SubText>
         <SearchBar />
+        <SearchDropdown />
       </Section>
     </Container>
   );
 }
 
 const Container = styled.div`
+  margin-top: 130px;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  height: 100vh;
+  height: 100%;
+  position: relative;
+  overflow: auto;
 `;
 
 const Section = styled.div`
@@ -39,9 +44,11 @@ const Section = styled.div`
   flex-direction: column;
   align-items: center;
   justify-content: flex-start;
-  padding-top: 200px;
-  height: 100vh;
+  padding-top: 50px;
+  box-sizing: border-box;
+  height: calc(100vh - 130px);
   width: 780px;
+  overflow: auto;
 `;
 
 const Logo = styled.div`

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -22,7 +22,6 @@ export default function Search() {
         </Title>
         <SubText>개발자들을 위한 한국어 발음 검색 서비스</SubText>
         <SearchBar />
-        <SearchDropdown />
       </Section>
     </Container>
   );

--- a/src/pages/search/index.jsx
+++ b/src/pages/search/index.jsx
@@ -24,7 +24,7 @@ const Section = styled.div`
   flex-direction: column;
   align-items: center;
   justify-content: flex-start;
-  padding-top: 200px;
+  padding-top: 130px;
   height: 100vh;
   width: 780px;
 `;

--- a/src/styles/commonStyles.jsx
+++ b/src/styles/commonStyles.jsx
@@ -32,6 +32,7 @@ export const Column = styled.div`
 
 // 검색창 스타일
 import { SearchOutlined } from "@ant-design/icons";
+import Link from "next/link";
 export const SearchBarContainer = styled.div`
   display: flex;
   align-items: center;
@@ -68,4 +69,9 @@ export const StyledSearchOutlined = styled(SearchOutlined)`
   height: 32px;
   font-size: 30px;
   color: #666666;
+`;
+
+export const ResetLink = styled(Link)`
+  text-decoration: none;
+  cursor: pointer;
 `;

--- a/src/styles/commonStyles.jsx
+++ b/src/styles/commonStyles.jsx
@@ -30,6 +30,21 @@ export const Column = styled.div`
   justify-content: center;
 `;
 
+export const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  position: fixed;
+  z-index: 100;
+  background-color: white;
+  top: 0;
+  left: 0;
+  height: 130px;
+  width: 100vw;
+  border-bottom: ${(props) => (props.$isHome ? "none" : "1px solid #cccccc")};
+`;
+
 // 검색창 스타일
 import { SearchOutlined } from "@ant-design/icons";
 import Link from "next/link";


### PR DESCRIPTION
1. 헤더 내 내 요청 라우터 - 상대경로에서 절대경로로 변경
2. isHome 경고 해결 - 접두사$ 사용하여 React의 경고를 피하면서도 컴포넌트에 필요한 속성을 전달할 수 있게 함.
3. 검색창 드롭다운 레이아웃 구현 및 검색 창 클릭 시 출력되도록 구현 ( 외부창 클릭 시 꺼짐 )
4. 드롭다운 내 최근검색어 ( 임시 리스트에서 관리 - 클릭하면 해당 검색결과로 이동, 및 삭제아이콘 클릭 시 최근검색어 출력 삭제 )
5. 페이지 헤더와 섹션의 구성이 화면높이 100vh를 넘어가 내용이 넘치치 않는데도 스크롤이 되는 문제 해결